### PR TITLE
Bump elixir to 1.10.2

### DIFF
--- a/elixir/1.10/Makefile
+++ b/elixir/1.10/Makefile
@@ -1,7 +1,7 @@
 REPO=verybigthings
 PLATFORM=elixir
 VERSION=1.10
-PATCH_VERSION=1.10.1
+PATCH_VERSION=1.10.2
 
 .DEFAULT_GOAL := build-and-push
 


### PR DESCRIPTION
### Changes
Bump elixir patch version to 1.10.2

Tested locally with a project without issues.