### PR TITLE
Bump elixir patch version to 1.10.3

### DIFF
--- a/elixir/1.10/Makefile
+++ b/elixir/1.10/Makefile
@@ -1,7 +1,7 @@
 REPO=verybigthings
 PLATFORM=elixir
 VERSION=1.10
-PATCH_VERSION=1.10.2
+PATCH_VERSION=1.10.3
 
 .DEFAULT_GOAL := build-and-push
 


### PR DESCRIPTION
### Changes
Bump elixir patch version to 1.10.3