### PR TITLE
Add elixir 1.11.0

### DIFF
--- a/elixir/1.11/Dockerfile
+++ b/elixir/1.11/Dockerfile
@@ -1,0 +1,72 @@
+FROM hexpm/elixir:1.11.0-erlang-22.3.4.12-debian-buster-20200607
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  curl \
+  gpg \
+  xz-utils \
+  wget
+
+ENV NODE_VERSION 12.19.0
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+    esac \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && set -ex \
+    && for key in \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+    && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+
+RUN set -ex \
+    && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+    ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+    && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+    && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+    && mkdir -p /opt \
+    && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+    && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+    && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+    && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
+# Tool to propagate singals from the container to the app
+ENV PID1_VERSION=0.1.2.0
+RUN curl -sSL "https://github.com/fpco/pid1/releases/download/v${PID1_VERSION}/pid1-${PID1_VERSION}-linux-x86_64.tar.gz" | tar xzf - -C /usr/local \
+    && chown root:root /usr/local/sbin \
+    && chown root:root /usr/local/sbin/pid1

--- a/elixir/1.11/Dockerfile
+++ b/elixir/1.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.11.0-erlang-22.3.4.12-debian-buster-20200607
+FROM hexpm/elixir:1.11.0-erlang-23.1-debian-buster-20200607
 
 RUN apt-get update && apt-get install -y \
   build-essential \

--- a/elixir/1.11/Makefile
+++ b/elixir/1.11/Makefile
@@ -1,0 +1,28 @@
+REPO=verybigthings
+PLATFORM=elixir
+VERSION=1.11
+PATCH_VERSION=1.11.0
+
+.DEFAULT_GOAL := build-and-push
+
+require-%:
+	@ if [ "${${*}}" = "" ]; then \
+		echo "ERROR: Environment variable not set: \"$*\""; \
+		exit 1; \
+	fi
+
+# ============= #
+
+build: require-VERSION require-PLATFORM require-PATCH_VERSION
+	docker build \
+		-t ${REPO}-${PLATFORM}:${VERSION} \
+		-t ${REPO}/${PLATFORM}:${VERSION} \
+		-t ${REPO}-${PLATFORM}:${PATCH_VERSION} \
+		-t ${REPO}/${PLATFORM}:${PATCH_VERSION} \
+		.
+
+push: require-VERSION require-PLATFORM require-PATCH_VERSION
+	docker push ${REPO}/${PLATFORM}:$(VERSION)
+	docker push ${REPO}/${PLATFORM}:$(PATCH_VERSION)
+
+build-and-push: require-VERSION require-PLATFORM require-PATCH_VERSION build push


### PR DESCRIPTION
### Changes
- Support for elixir 1.11.0 with https://github.com/hexpm/bob#docker-images as base image
- Bump node to 12.19.0 version
- Bump yarn to 1.22.5
- Tested with a VBT project without issues