### PR TITLE
Bump elixir to 1.11.4

### DIFF
--- a/elixir/1.11/Dockerfile
+++ b/elixir/1.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.11.3-erlang-23.2-debian-buster-20201012
+FROM hexpm/elixir:1.11.4-erlang-23.2-debian-buster-20201012
 
 RUN apt-get update && apt-get install -y \
   build-essential \

--- a/elixir/1.11/Makefile
+++ b/elixir/1.11/Makefile
@@ -1,7 +1,7 @@
 REPO=verybigthings
 PLATFORM=elixir
 VERSION=1.11
-PATCH_VERSION=1.11.3
+PATCH_VERSION=1.11.4
 
 .DEFAULT_GOAL := build-and-push
 


### PR DESCRIPTION
### Changes
Bump elixir to 1.11.4: https://github.com/elixir-lang/elixir/releases/tag/v1.11.4