### PR TITLE
Bump erlang to 23.3

### DIFF
--- a/elixir/1.11/Dockerfile
+++ b/elixir/1.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.11.4-erlang-23.2-debian-buster-20201012
+FROM hexpm/elixir:1.11.4-erlang-23.3-debian-buster-20210208
 
 RUN apt-get update && apt-get install -y \
   build-essential \


### PR DESCRIPTION
### Changes
Bump erlang to `23.3` in elixir 1.11.4 version.