### PR TITLE
Bump elixir 1.12.1

### DIFF
--- a/elixir/1.12/Dockerfile
+++ b/elixir/1.12/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.12.0-erlang-24.0-debian-buster-20210326
+FROM hexpm/elixir:1.12.1-erlang-24.0-debian-buster-20210326
 
 RUN apt-get update && apt-get install -y \
   build-essential \
@@ -45,7 +45,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
-    
+
 ENV YARN_VERSION 1.22.10
 
 RUN set -ex \

--- a/elixir/1.12/Makefile
+++ b/elixir/1.12/Makefile
@@ -1,7 +1,7 @@
 REPO=verybigthings
 PLATFORM=elixir
 VERSION=1.12
-PATCH_VERSION=1.12.0
+PATCH_VERSION=1.12.1
 
 .DEFAULT_GOAL := build-and-push
 


### PR DESCRIPTION
### Changes
Bump elixir to 1.12.1: https://github.com/elixir-lang/elixir/releases/tag/v1.12.1