### PR TITLE
Rebuild elixir 1.11

### DIFF
--- a/elixir/1.11/Dockerfile
+++ b/elixir/1.11/Dockerfile
@@ -1,6 +1,6 @@
 FROM hexpm/elixir:1.11.4-erlang-23.3-debian-buster-20210208
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get --allow-releaseinfo-change update && apt-get install -y \
   build-essential \
   curl \
   gpg \

--- a/elixir/1.11/Dockerfile
+++ b/elixir/1.11/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y \
   xz-utils \
   wget
 
-ENV NODE_VERSION 12.19.0
+ENV NODE_VERSION 14.16.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -34,9 +34,8 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
     B9E2F5981AA6E0CD28160D9FF13993A75599653C \
     ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
     done \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -46,15 +45,14 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.10
 
 RUN set -ex \
     && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \
     ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
     done \
     && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
     && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \


### PR DESCRIPTION
### Changes
All changes are on elixir 1.11:
- Image will have to be rebuilt due to following issue:
```
Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates
```
Since the original `hexpm/elixir` image has not been updated, a workaround has been implemented.
- Update node and yarn version
```
yarn 1.22.10
node 14.16.1
```