### PR TITLE
Bump elixir to 1.12.3

### DIFF
--- a/elixir/1.12/Dockerfile
+++ b/elixir/1.12/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.12.2-erlang-24.0-debian-buster-20210326
+FROM hexpm/elixir:1.12.3-erlang-24.0-debian-bullseye-20210902
 
 RUN apt-get update && apt-get install -y \
   build-essential \

--- a/elixir/1.12/Makefile
+++ b/elixir/1.12/Makefile
@@ -1,7 +1,7 @@
 REPO=verybigthings
 PLATFORM=elixir
 VERSION=1.12
-PATCH_VERSION=1.12.2
+PATCH_VERSION=1.12.3
 
 .DEFAULT_GOAL := build-and-push
 


### PR DESCRIPTION
Hello!
I've updated the image, although had to move debian from buster to bullseye (new stable).
Local image build passes. Used the new image as base for localdrive, all ok.

Also, explanation to why are these commands duplicated is very much appreciated
```
build: require-VERSION require-PLATFORM require-PATCH_VERSION
	docker build \
		-t ${REPO}-${PLATFORM}:${VERSION} \
		-t ${REPO}/${PLATFORM}:${VERSION} \
		-t ${REPO}-${PLATFORM}:${PATCH_VERSION} \
		-t ${REPO}/${PLATFORM}:${PATCH_VERSION} \
```

